### PR TITLE
remove 'cant extract value for key' log

### DIFF
--- a/src/main/java/pl/allegro/tech/opel/FieldAccessExpressionNode.java
+++ b/src/main/java/pl/allegro/tech/opel/FieldAccessExpressionNode.java
@@ -1,15 +1,9 @@
 package pl.allegro.tech.opel;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.lang.invoke.MethodHandles;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 class FieldAccessExpressionNode implements OpelNode {
-    private final static Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
     private final OpelNode subject;
     private final OpelNode fieldName;
 
@@ -26,7 +20,6 @@ class FieldAccessExpressionNode implements OpelNode {
     private CompletableFuture<?> extractValueFromMap(CompletableFuture<?> obj, CompletableFuture<?> key) {
         return obj.thenCombine(key, (it, k) -> {
             if (it == null) {
-                logger.info("Can't extract value for key '" + k + "' from null");
                 return null;
             }
             if (it instanceof Map) {

--- a/src/main/java/pl/allegro/tech/opel/MapAccessExpressionNode.java
+++ b/src/main/java/pl/allegro/tech/opel/MapAccessExpressionNode.java
@@ -1,17 +1,11 @@
 package pl.allegro.tech.opel;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.lang.invoke.MethodHandles;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 public class MapAccessExpressionNode implements OpelNode {
-    private final static Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
     private final OpelNode subject;
     private final OpelNode fieldName;
 
@@ -28,7 +22,6 @@ public class MapAccessExpressionNode implements OpelNode {
     private CompletableFuture<?> extractValueFromListOrMap(CompletableFuture<?> obj, CompletableFuture<?> key) {
         return obj.thenCombine(key, (it, k) -> {
             if (it == null) {
-                logger.info("Can't extract value for key '" + k + "' from null");
                 return null;
             }
             if (it instanceof Map) {


### PR DESCRIPTION
It looks like property lookup in OPEL is short-circuiting while a null is encountered. It's an expected behaviour, so it looks like logging the occurrence of that case, makes a little sense.